### PR TITLE
mountinfo: add GetMountsFromReader

### DIFF
--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -1,9 +1,19 @@
 package mountinfo
 
+import "io"
+
 // GetMounts retrieves a list of mounts for the current running process,
 // with an optional filter applied (use nil for no filter).
 func GetMounts(f FilterFunc) ([]*Info, error) {
 	return parseMountTable(f)
+}
+
+// GetMountsFromReader retrieves a list of mounts from the
+// reader provided, with an optional filter applied (use nil
+// for no filter). This can be useful in tests or benchmarks
+// that provide a fake mountinfo data.
+func GetMountsFromReader(reader io.Reader, f FilterFunc) ([]*Info, error) {
+	return parseInfoFile(reader, f)
 }
 
 // Mounted determines if a specified mountpoint has been mounted.


### PR DESCRIPTION
Some code have tests or benchmarks that come with fake mountinfo.
To switch those to use moby/sys/mountinfo without any major rework
of those tests and benchmarks we need to provide a way to work
with such fake mountinfo.

This is probably more important for benchmarks, since without
this we can't make any comparisons after switching to moby/sys.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>